### PR TITLE
Upgrade black version

### DIFF
--- a/amazon_cloud_code_generator/cmd/refresh_modules.py
+++ b/amazon_cloud_code_generator/cmd/refresh_modules.py
@@ -75,7 +75,12 @@ def get_module_added_ins(module_name: str, git_dir: str) -> Dict:
             if not added_ins["module"]:
                 added_ins["module"] = tag
             content = "\n".join(
-                run_git(git_dir, "cat-file", "--textconv", f"{tag}:{module}",)
+                run_git(
+                    git_dir,
+                    "cat-file",
+                    "--textconv",
+                    f"{tag}:{module}",
+                )
             )
             try:
                 ast_file = redbaron.RedBaron(content)
@@ -241,7 +246,11 @@ class AnsibleModule:
     def renderer(self, target_dir: str, next_version: str):
         added_ins = get_module_added_ins(self.name, git_dir=target_dir / ".git")
 
-        documentation = generate_documentation(self, added_ins, next_version,)
+        documentation = generate_documentation(
+            self,
+            added_ins,
+            next_version,
+        )
         arguments = generate_argument_spec(documentation["options"])
         documentation_to_string = format_documentation(documentation)
         required_if = gen_required_if(self.schema)
@@ -270,7 +279,10 @@ def main():
         help="location of the target repository (default: ./cloud)",
     )
     parser.add_argument(
-        "--next-version", type=str, default="TODO", help="the next major version",
+        "--next-version",
+        type=str,
+        default="TODO",
+        help="the next major version",
     )
     args = parser.parse_args()
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,13 +12,13 @@ commands =
 
 [testenv:black]
 deps =
-  black==19.10b0
+  black >= 22.0, < 23.0
 commands =
   black {toxinidir}/amazon_cloud_code_generator/
 
 [testenv:linters]
 deps =
-  black==19.10b0
+  {[testenv:black]deps}
   flake8
 install_command = pip install {opts} {packages}
 commands =


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We should move on to the non-beta release of black. I think pinning to
the calendar year, per the black stability policy, seems reasonable:
https://black.readthedocs.io/en/stable/the_black_code_style/index.html#stability-policy.

This should also fix the current CI failure where black won't install.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
