### PR TITLE
Add identifier parameter for modules with compound identifiers

### DIFF
--- a/amazon_cloud_code_generator/cmd/generator.py
+++ b/amazon_cloud_code_generator/cmd/generator.py
@@ -353,6 +353,19 @@ def generate_documentation(
             "default": True,
         }
 
+    if len(docs.primary_identifier) > 1:
+        # If a resource has more than one primary identifier, the user can decide to either
+        # specify all the primary identifiers or use the identifier parameter as a string
+        # consisting of the multiple identifiers strung together
+        # https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/resource-identifier.html
+        documentation["options"]["identifier"] = {
+            "description": [
+                "For compound primary identifiers, to specify the primary identifier as a string, list each in the order that they are specified in the identifier list definition, separated by |.",
+                "For more details, visit U(https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/resource-identifier.html).",
+            ],
+            "type": "str",
+        }
+
     module_from_config = get_module_from_config(module_name)
     if module_from_config and "documentation" in module_from_config:
         for k, v in module_from_config["documentation"].items():

--- a/amazon_cloud_code_generator/cmd/refresh_modules.py
+++ b/amazon_cloud_code_generator/cmd/refresh_modules.py
@@ -143,21 +143,18 @@ def gen_required_if(schema: Dict) -> List:
     # For compound primary identifiers consisting of multiple resource properties strung together,
     # use the property values in the order that they are specified in the primary identifier definition
     if len(primary_idenfifier) > 1:
-        entries.append(["state", "list", list(set(primary_idenfifier[:-1])), True])
+        entries.append(["state", "list", primary_idenfifier[:-1], True])
         _primary_idenfifier.append("identifier")
 
     entries.append(
         [
             "state",
             "present",
-            list(set([*_primary_idenfifier, *required])),
+            [*_primary_idenfifier, *required],
             True,
         ]
     )
-    [
-        entries.append(["state", state, list(_primary_idenfifier), True])
-        for state in states
-    ]
+    [entries.append(["state", state, _primary_idenfifier, True]) for state in states]
 
     return entries
 

--- a/amazon_cloud_code_generator/cmd/refresh_modules.py
+++ b/amazon_cloud_code_generator/cmd/refresh_modules.py
@@ -277,8 +277,6 @@ class AnsibleModule:
 
         arguments = generate_argument_spec(documentation["options"])
         documentation_to_string = format_documentation(documentation)
-        required_if = gen_required_if(self.schema)
-        mutually_exclusive = gen_required_if(self.schema)
         content = jinja2_renderer(
             self.template_file,
             arguments=indent(arguments, 4),
@@ -287,8 +285,8 @@ class AnsibleModule:
             resource_type=f"'{self.schema.get('typeName')}'",
             params=indent(generate_params(documentation["options"]), 4),
             primary_identifier=self.schema["primaryIdentifier"],
-            required_if=required_if,
-            mutually_exclusive=mutually_exclusive,
+            required_if=gen_required_if(self.schema),
+            mutually_exclusive=get_mutually_exclusive(self.schema),
             create_only_properties=self.schema.get("createOnlyProperties", {}),
             handlers=list(self.schema.get("handlers", {}).keys()),
         )

--- a/amazon_cloud_code_generator/cmd/refresh_modules.py
+++ b/amazon_cloud_code_generator/cmd/refresh_modules.py
@@ -138,18 +138,26 @@ def gen_required_if(schema: Dict) -> List:
     entries: List = []
     states = ["absent", "get"]
 
-    entries.append(
-        ["state", "present", list(set([*primary_idenfifier, *required])), True]
-    )
+    _primary_idenfifier = copy.copy(primary_idenfifier)
 
-    [
-        entries.append(["state", state, list(set(primary_idenfifier)), True])
-        for state in states
-    ]
     # For compound primary identifiers consisting of multiple resource properties strung together,
     # use the property values in the order that they are specified in the primary identifier definition
     if len(primary_idenfifier) > 1:
         entries.append(["state", "list", list(set(primary_idenfifier[:-1])), True])
+        _primary_idenfifier.append("identifier")
+
+    entries.append(
+        [
+            "state",
+            "present",
+            list(set([*_primary_idenfifier, *required])),
+            True,
+        ]
+    )
+    [
+        entries.append(["state", state, list(_primary_idenfifier), True])
+        for state in states
+    ]
 
     return entries
 

--- a/amazon_cloud_code_generator/cmd/refresh_modules.py
+++ b/amazon_cloud_code_generator/cmd/refresh_modules.py
@@ -127,17 +127,7 @@ def gen_mutually_exclusive(schema: Dict) -> List:
     entries: List = []
 
     if len(primary_idenfifier) > 1:
-       entries.append([tuple(primary_idenfifier), "identifier"])
-
-    return entries
-
-
-def gen_required_together(schema: Dict) -> List:
-    primary_idenfifier = schema.get("primaryIdentifier", [])
-    entries: List = []
-
-    if len(primary_idenfifier) > 1:
-        entries.append(primary_idenfifier)
+        entries.append([tuple(primary_idenfifier), "identifier"])
 
     return entries
 
@@ -148,24 +138,35 @@ def gen_required_if(schema: Dict) -> List:
     entries: List = []
     states = ["absent", "get"]
 
-    if len(primary_idenfifier) == 1:
-        entries.append(
-            ["state", "present", list(set([*primary_idenfifier, *required])), True]
-        )
-    
-        [
-            entries.append(["state", state, list(set(primary_idenfifier)), True])
-            for state in states
-        ]
+    entries.append(
+        ["state", "present", list(set([*primary_idenfifier, *required])), True]
+    )
+
+    [
+        entries.append(["state", state, list(set(primary_idenfifier)), True])
+        for state in states
+    ]
     # For compound primary identifiers consisting of multiple resource properties strung together,
     # use the property values in the order that they are specified in the primary identifier definition
     if len(primary_idenfifier) > 1:
-        entries.append(
-            ["state", "present", list(set([*required])), True]
-        )
         entries.append(["state", "list", list(set(primary_idenfifier[:-1])), True])
 
     return entries
+
+
+def ensure_all_identifiers_defined(schema: Dict) -> str:
+    primary_idenfifier = schema.get("primaryIdentifier", [])
+    new_content: str = "if state in ('present', 'absent', 'get', 'describe') and module.params.get('identifier') is None:\n"
+    new_content += 8 * " "
+    new_content += f"if not  module.params.get('{primary_idenfifier[0]}')" + " ".join(
+        map(lambda x: f" or not module.params.get('{x}')", primary_idenfifier[1:])
+    )
+    new_content += ":\n" + 12 * " "
+    new_content += (
+        "module.fail_json(f'You must specify both {*identifier, } identifiers.')\n"
+    )
+
+    return new_content
 
 
 def format_documentation(documentation: Iterable) -> str:
@@ -302,7 +303,9 @@ class AnsibleModule:
             primary_identifier=self.schema["primaryIdentifier"],
             required_if=gen_required_if(self.schema),
             mutually_exclusive=gen_mutually_exclusive(self.schema),
-            required_together=gen_required_together(self.schema),
+            ensure_all_identifiers_defined=ensure_all_identifiers_defined(self.schema)
+            if len(self.schema["primaryIdentifier"]) > 1
+            else "",
             create_only_properties=self.schema.get("createOnlyProperties", {}),
             handlers=list(self.schema.get("handlers", {}).keys()),
         )

--- a/amazon_cloud_code_generator/cmd/refresh_modules.py
+++ b/amazon_cloud_code_generator/cmd/refresh_modules.py
@@ -122,6 +122,16 @@ def generate_params(definitions: Iterable) -> str:
     return params
 
 
+def get_mutually_exclusive(schema: Dict) -> List:
+    primary_idenfifier = schema.get("primaryIdentifier", [])
+    entries: List = []
+
+    if len(primary_idenfifier) > 1:
+        entries.append([primary_idenfifier, "identifier"])
+
+    return entries
+
+
 def gen_required_if(schema: Dict) -> List:
     primary_idenfifier = schema.get("primaryIdentifier", [])
     required = schema.get("required", [])
@@ -268,6 +278,7 @@ class AnsibleModule:
         arguments = generate_argument_spec(documentation["options"])
         documentation_to_string = format_documentation(documentation)
         required_if = gen_required_if(self.schema)
+        mutually_exclusive = gen_required_if(self.schema)
         content = jinja2_renderer(
             self.template_file,
             arguments=indent(arguments, 4),
@@ -277,6 +288,7 @@ class AnsibleModule:
             params=indent(generate_params(documentation["options"]), 4),
             primary_identifier=self.schema["primaryIdentifier"],
             required_if=required_if,
+            mutually_exclusive=mutually_exclusive,
             create_only_properties=self.schema.get("createOnlyProperties", {}),
             handlers=list(self.schema.get("handlers", {}).keys()),
         )

--- a/amazon_cloud_code_generator/data/plugins/module_utils/core.py
+++ b/amazon_cloud_code_generator/data/plugins/module_utils/core.py
@@ -267,7 +267,9 @@ class CloudControlResource(object):
             )
         except self.client.exceptions.ResourceNotFoundException:
             if self.module.params.get("identifier"):
-                self.module.fail_json(f"You must specify both {*primary_identifier, } to create a new resource. Option identifier must only be used to manipulate an existing resource.")
+                self.module.fail_json(
+                    f"You must specify both {*primary_identifier, } to create a new resource. Option identifier must only be used to manipulate an existing resource."
+                )
             results["changed"] |= self.create_resource(type_name, params)
         except (
             botocore.exceptions.BotoCoreError,

--- a/amazon_cloud_code_generator/data/plugins/module_utils/core.py
+++ b/amazon_cloud_code_generator/data/plugins/module_utils/core.py
@@ -249,19 +249,25 @@ class CloudControlResource(object):
 
         resource = None
 
-        for id in primary_identifier:
-            identifier[
-                snake_to_camel(id, capitalize_first=True)
-            ] = self.module.params.get(id)
+        if self.module.params.get("identifier"):
+            identifier = self.module.params.get("identifier")
+        else:
+            for id in primary_identifier:
+                identifier[
+                    snake_to_camel(id, capitalize_first=True)
+                ] = self.module.params.get(id)
+            identifier = json.dumps(identifier)
 
         try:
             resource = self.client.get_resource(
-                TypeName=type_name, Identifier=json.dumps(identifier)
+                TypeName=type_name, Identifier=identifier
             )
             results = self.update_resource(
                 resource, params, create_only_params, handlers
             )
         except self.client.exceptions.ResourceNotFoundException:
+            if self.module.params.get("identifier"):
+                self.module.fail_json(f"You must specify both {*primary_identifier, } to create a new resource. Option identifier must only be used to manipulate an existing resource.")
             results["changed"] |= self.create_resource(type_name, params)
         except (
             botocore.exceptions.BotoCoreError,
@@ -337,14 +343,18 @@ class CloudControlResource(object):
         identifier: Dict = {}
         response: Dict = {}
 
-        for id in primary_identifier:
-            identifier[
-                snake_to_camel(id, capitalize_first=True)
-            ] = self.module.params.get(id)
+        if self.module.params.get("identifier"):
+            identifier = self.module.params.get("identifier")
+        else:
+            for id in primary_identifier:
+                identifier[
+                    snake_to_camel(id, capitalize_first=True)
+                ] = self.module.params.get(id)
+            identifier = json.dumps(identifier)
 
         try:
             response = self.client.get_resource(
-                TypeName=type_name, Identifier=json.dumps(identifier)
+                TypeName=type_name, Identifier=identifier
             )
         except self.client.exceptions.ResourceNotFoundException:
             return changed

--- a/amazon_cloud_code_generator/data/plugins/module_utils/core.py
+++ b/amazon_cloud_code_generator/data/plugins/module_utils/core.py
@@ -268,7 +268,7 @@ class CloudControlResource(object):
         except self.client.exceptions.ResourceNotFoundException:
             if self.module.params.get("identifier"):
                 self.module.fail_json(
-                    f"You must specify both {*primary_identifier, } to create a new resource. Option identifier must only be used to manipulate an existing resource."
+                    f"You must specify both {*primary_identifier, } to create a new resource. The identifier parameter can only be used to manipulate an existing resource."
                 )
             results["changed"] |= self.create_resource(type_name, params)
         except (

--- a/amazon_cloud_code_generator/data/tests/integration/targets/eks/tasks/eks_fargate_profile.yml
+++ b/amazon_cloud_code_generator/data/tests/integration/targets/eks/tasks/eks_fargate_profile.yml
@@ -119,7 +119,6 @@
   amazon.cloud.eks_fargate_profile:
     fargate_profile_name: "{{ eks_fargate_profile_name_a }}"
     state: present
-    #cluster_name: "{{ eks_cluster_name }}"
     pod_execution_role_arn: "{{ _result_create_iam_role_fp.arn }}"
     subnets: >-
       {{_result_create_subnets.results|selectattr('subnet.tags.Name', 'contains',

--- a/amazon_cloud_code_generator/data/tests/integration/targets/eks/tasks/eks_fargate_profile.yml
+++ b/amazon_cloud_code_generator/data/tests/integration/targets/eks/tasks/eks_fargate_profile.yml
@@ -8,6 +8,14 @@
   ignore_errors: true
   register: _result_delete_fp
 
+- name: Delete Fargate Profile b (if present) using identifier option
+  amazon.cloud.eks_fargate_profile:
+    identifier: "{{ eks_cluster_name }}|{{ eks_fargate_profile_name_b }}"
+    state: absent
+    wait: true
+  ignore_errors: true
+  register: _result_delete_fp
+
 - name: Delete Fargate Profile a (if present)
   amazon.cloud.eks_fargate_profile:
     fargate_profile_name: "{{ eks_fargate_profile_name_a }}"
@@ -107,6 +115,35 @@
     that:
       - _result_create_fp.changed
 
+- name: Create Fargate Profile with fargate_profile_name option only (expected to fail)
+  amazon.cloud.eks_fargate_profile:
+    fargate_profile_name: "{{ eks_fargate_profile_name_a }}"
+    state: present
+    #cluster_name: "{{ eks_cluster_name }}"
+    pod_execution_role_arn: "{{ _result_create_iam_role_fp.arn }}"
+    subnets: >-
+      {{_result_create_subnets.results|selectattr('subnet.tags.Name', 'contains',
+      'private') | map(attribute='subnet.id') }}
+    selectors: "{{ selectors }}"
+    wait: true
+    tags: "{{ tags }}"
+  register: _result_create_fp
+  ignore_errors: true
+
+- name: Create Fargate Profile with identifier option only (expected to fail)
+  amazon.cloud.eks_fargate_profile:
+    identifier: "{{ eks_cluster_name }}|{{ eks_fargate_profile_name_b }}"
+    state: present
+    pod_execution_role_arn: "{{ _result_create_iam_role_fp.arn }}"
+    subnets: >-
+      {{_result_create_subnets.results|selectattr('subnet.tags.Name', 'contains',
+      'private') | map(attribute='subnet.id') }}
+    selectors: "{{ selectors }}"
+    wait: true
+    tags: "{{ tags }}"
+  register: _result_create_fp
+  ignore_errors: true
+
 - name: Create Fargate Profile a with wait
   amazon.cloud.eks_fargate_profile:
     fargate_profile_name: "{{ eks_fargate_profile_name_a }}"
@@ -196,6 +233,27 @@
   register: _result_update_tags_fp
   tags:
     - docs
+
+- name: Assert result is changed (check mode)
+  assert:
+    that:
+      - _result_update_tags_fp.changed
+
+- name: Update tags in Fargate Profile a with wait and identifier option (check mode)
+  amazon.cloud.eks_fargate_profile:
+    identifier: "{{ eks_cluster_name }}|{{ eks_fargate_profile_name_a }}"
+    state: present
+    pod_execution_role_arn: "{{ _result_create_iam_role_fp.arn }}"
+    subnets: >-
+      {{_result_create_subnets.results|selectattr('subnet.tags.Name', 'contains',
+      'private') | map(attribute='subnet.id') }}
+    selectors: "{{ selectors }}"
+    wait: true
+    tags:
+      env: test
+      test: foo
+  check_mode: True
+  register: _result_update_tags_fp
 
 - name: Assert result is changed (check mode)
   assert:
@@ -417,10 +475,9 @@
     that:
       - _result_delete_fp.changed
 
-- name: Delete Fargate Profile b
+- name: Delete Fargate Profile b using identifier
   amazon.cloud.eks_fargate_profile:
-    fargate_profile_name: "{{ eks_fargate_profile_name_b }}"
-    cluster_name: "{{ eks_cluster_name }}"
+    identifier: "{{ eks_cluster_name }}|{{ eks_fargate_profile_name_b }}"
     state: absent
     wait: true
     wait_timeout: 900

--- a/amazon_cloud_code_generator/templates/default_module.j2
+++ b/amazon_cloud_code_generator/templates/default_module.j2
@@ -23,7 +23,11 @@ def main():
         {{ mutually_exclusive|join(",") }}
     ]
 
-    module = AnsibleAWSModule(argument_spec=argument_spec, required_if=required_if, mutually_exclusive=mutually_exclusive, supports_check_mode=True)
+    required_together = [
+        {{ required_together|join(",") }}
+    ]
+
+    module = AnsibleAWSModule(argument_spec=argument_spec, required_if=required_if, mutually_exclusive=mutually_exclusive, required_together=required_together, supports_check_mode=True)
     cloud = CloudControlResource(module)
 
     type_name = {{resource_type}}

--- a/amazon_cloud_code_generator/templates/default_module.j2
+++ b/amazon_cloud_code_generator/templates/default_module.j2
@@ -18,16 +18,11 @@ def main():
     required_if = [
         {{ required_if|join(",") }}
     ]
-    
     mutually_exclusive = [
         {{ mutually_exclusive|join(",") }}
     ]
 
-    required_together = [
-        {{ required_together|join(",") }}
-    ]
-
-    module = AnsibleAWSModule(argument_spec=argument_spec, required_if=required_if, mutually_exclusive=mutually_exclusive, required_together=required_together, supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec=argument_spec, required_if=required_if, mutually_exclusive=mutually_exclusive, supports_check_mode=True)
     cloud = CloudControlResource(module)
 
     type_name = {{resource_type}}
@@ -53,7 +48,7 @@ def main():
 
     state = module.params.get('state')
     identifier = {{primary_identifier}}
-
+    {{ ensure_all_identifiers_defined }}
     results = {"changed": False, "result": {}}
 
     if state == "list":

--- a/amazon_cloud_code_generator/templates/default_module.j2
+++ b/amazon_cloud_code_generator/templates/default_module.j2
@@ -18,8 +18,12 @@ def main():
     required_if = [
         {{ required_if|join(",") }}
     ]
+    
+    mutually_exclusive = [
+        {{ mutually_exclusive|join(",") }}
+    ]
 
-    module = AnsibleAWSModule(argument_spec=argument_spec, required_if=required_if, supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec=argument_spec, required_if=required_if, mutually_exclusive=mutually_exclusive, supports_check_mode=True)
     cloud = CloudControlResource(module)
 
     type_name = {{resource_type}}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add identifier parameter for modules with compound identifiers
https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/resource-identifier.html

I'd like to have this merged after https://github.com/ansible-collections/amazon_cloud_code_generator/pull/28
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
