### PR TITLE
Add test alias for zuul

### DIFF
--- a/amazon_cloud_code_generator/data/tests/integration/targets/eks/aliases
+++ b/amazon_cloud_code_generator/data/tests/integration/targets/eks/aliases
@@ -1,3 +1,4 @@
 slow
 
 cloud/aws
+zuul/aws/cloud_control

--- a/amazon_cloud_code_generator/data/tests/integration/targets/logs/aliases
+++ b/amazon_cloud_code_generator/data/tests/integration/targets/logs/aliases
@@ -1,1 +1,2 @@
 cloud/aws
+zuul/aws/cloud_control

--- a/amazon_cloud_code_generator/data/tests/integration/targets/s3/aliases
+++ b/amazon_cloud_code_generator/data/tests/integration/targets/s3/aliases
@@ -1,1 +1,2 @@
 cloud/aws
+zuul/aws/cloud_control


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
All test targets need the zuul/aws/cloud_config alias to be run in zuul.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
